### PR TITLE
Fixed Error Set Owner When Using React OPTIONS

### DIFF
--- a/config/policies/setOwner.js
+++ b/config/policies/setOwner.js
@@ -6,12 +6,32 @@
 
 module.exports = async (ctx, next) => {
 
-  const user = ctx.state.user;
+  const { role, id } = ctx.state.user
 
-  if (user.role.name == "Teacher") {
-    const { body } = ctx.request;
+  if (role.name == "Teacher") {
 
-    body.user = user.id;
+    const { body } = ctx.request
+
+    if(body.data) {
+      
+      // parse data string to object
+      const parseData = JSON.parse(body.data)
+
+      // inject userid to object
+      const injectData = {
+        ...parseData,
+        user: id
+      }
+
+      // parse object to data string
+      const newData = JSON.stringify(injectData)
+
+      // set body
+      body.data = newData
+
+    } else {
+      body.user = id
+    }
 
     return await next();
   }


### PR DESCRIPTION
# BUG
- When submit post data from react, user can't inject to body request

# Information
- this because react using OPTIONS before POST and using `data` object with stringify object inside